### PR TITLE
fix: fix prompt_only dataset eos token

### DIFF
--- a/align_anything/datasets/text_audio_to_text/prompt_only.py
+++ b/align_anything/datasets/text_audio_to_text/prompt_only.py
@@ -100,6 +100,8 @@ class PromptOnlyDataset(Dataset):
 
     def preprocess(self, raw_sample: dict[str, Any]) -> PromptOnlySample:
         formatted_prompt, meta_info = self.template.format_prompt_only_sample(raw_sample)
+        if formatted_prompt[-1] != self.tokenizer.eos_token:
+            formatted_prompt += self.tokenizer.eos_token
         return_dict = {}
 
         # return necessary information

--- a/align_anything/datasets/text_image_to_text/prompt_only.py
+++ b/align_anything/datasets/text_image_to_text/prompt_only.py
@@ -100,6 +100,8 @@ class PromptOnlyDataset(Dataset):
 
     def preprocess(self, raw_sample: dict[str, Any]) -> PromptOnlySample:
         formatted_prompt, meta_info = self.template.format_prompt_only_sample(raw_sample)
+        if formatted_prompt[-1] != self.tokenizer.eos_token:
+            formatted_prompt += self.tokenizer.eos_token
         return_dict = {}
 
         # return necessary information

--- a/align_anything/datasets/text_to_text/prompt_only.py
+++ b/align_anything/datasets/text_to_text/prompt_only.py
@@ -97,6 +97,8 @@ class PromptOnlyDataset(Dataset):
     def preprocess(self, raw_sample: dict[str, Any]) -> PromptOnlySample:
         return_dict = {}
         raw_text, _ = self.template.format_prompt_only_sample(raw_sample)
+        if raw_text[-1] != self.tokenizer.eos_token:
+            raw_text += self.tokenizer.eos_token
         return_dict['input_ids'] = self.tokenize(raw_text)
 
         return return_dict


### PR DESCRIPTION
# Description

fix `prompt_only` dataset eos token

## Motivation and Context

The eos token of `prompt_only` dataset is missing. This PR fix this issue.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/align-anything/blob/HEAD/.github/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
