### PR TITLE
feat: support vllm sampling in ppo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Align-Anything aims to align any modality large models (any-to-any models), incl
 
 - **`Coming Soon`** ⚡️⚡️⚡️ We plan to separate the evaluation component from align-anything and establish eval-anything as a dedicated repository for large-scale evaluation of any-to-any models. Meanwhile, align-anything will remain focused on the post-training alignment of any-to-any models.
 
-- **[2025.03.30]** 🚀🚀🚀 We support wrapping the `actor` model with [vLLM engine](https://github.com/vllm-project/vllm) for sequence generation in `text-to-text ppo` training. It greatly accelerates the ppo training process. Our results show that with vLLM engine, it only takes 22 minutes to finish ppo, while the baseline case needs ~150 minutes. 
+- **[2025.03.31]** 🚀🚀🚀 We support wrapping the `actor` model with [vLLM engine](https://github.com/vllm-project/vllm) for sequence generation in `text-to-text ppo` training. It greatly accelerates the ppo training process. Our results show that with vLLM engine, it only takes 22 minutes to finish ppo, while the baseline case needs ~150 minutes. 
 
     > 😊 Our implementation is encouraged by [OpenRLHF](https://github.com/OpenRLHF/OpenRLHF), which is a great project for RLHF training.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Align-Anything aims to align any modality large models (any-to-any models), incl
 
 - **`Coming Soon`** ⚡️⚡️⚡️ We plan to separate the evaluation component from align-anything and establish eval-anything as a dedicated repository for large-scale evaluation of any-to-any models. Meanwhile, align-anything will remain focused on the post-training alignment of any-to-any models.
 
+- **[2025.03.30]** 🚀🚀🚀 We support wrapping the `actor` model with [vLLM engine](https://github.com/vllm-project/vllm) for sequence generation in `text-to-text ppo` training. It greatly accelerates the ppo training process. Our results show that with vLLM engine, it only takes 22 minutes to finish ppo, while the baseline case needs ~150 minutes. 
+
+    > 😊 Our implementation is encouraged by [OpenRLHF](https://github.com/OpenRLHF/OpenRLHF), which is a great project for RLHF training.
+
 - **[2025.03.27]** 📜📜📜 We release the tutorial on DPO training for `text-to-text` models. Check out the [cookbook_en](./cookbooks/en/text_to_text_dpo.ipynb) (for English) and [cookbook_zh](./cookbooks/zh/text_to_text_dpo.ipynb) (for Chinese).
 
 - **[2025.03.15]** 📜📜📜 We release the tutorial for extending modality from `text-to-text` to `text-image-to-text` models. Check out the [cookbook_en](./cookbooks/en/modality_scaling.ipynb) (for English) and [cookbook_zh](./cookbooks/zh/modality_scaling.ipynb) (for Chinese).

--- a/align_anything/configs/format_dataset.py
+++ b/align_anything/configs/format_dataset.py
@@ -189,8 +189,8 @@ class Alpaca(BaseFormatter):
         prompt = ' '.join((raw_sample['instruction'], raw_sample['input']))
         response = raw_sample['output']
         return [
-            {'role': 'user', 'content': [{'type': 'text', 'text': prompt}]},
-            {'role': 'assistant', 'content': [{'type': 'text', 'text': response}]},
+            {'role': 'user', 'content': prompt},
+            {'role': 'assistant', 'content': response},
         ], {}
 
 
@@ -207,13 +207,13 @@ class PKUSafeRLHF(BaseFormatter):
         prompt = raw_sample['prompt']
 
         better_conversation = [
-            {'role': 'user', 'content': [{'type': 'text', 'text': prompt}]},
-            {'role': 'assistant', 'content': [{'type': 'text', 'text': better_response}]},
+            {'role': 'user', 'content': prompt},
+            {'role': 'assistant', 'content': better_response},
         ]
 
         worse_conversation = [
-            {'role': 'user', 'content': [{'type': 'text', 'text': prompt}]},
-            {'role': 'assistant', 'content': [{'type': 'text', 'text': worse_response}]},
+            {'role': 'user', 'content': prompt},
+            {'role': 'assistant', 'content': worse_response},
         ]
 
         meta_info = {
@@ -228,7 +228,7 @@ class PKUSafeRLHF(BaseFormatter):
     ) -> tuple[list[dict[str, Any]], str]:
         prompt = raw_sample['prompt']
         return [
-            {'role': 'user', 'content': [{'type': 'text', 'text': prompt}]},
+            {'role': 'user', 'content': prompt},
         ], {}
 
     def format_unmatched_supervised_sample(
@@ -237,8 +237,8 @@ class PKUSafeRLHF(BaseFormatter):
         prompt = raw_sample_for_prompt['prompt']
         response = raw_sample_for_response['response_1']
         return [
-            {'role': 'user', 'content': [{'type': 'text', 'text': prompt}]},
-            {'role': 'assistant', 'content': [{'type': 'text', 'text': response}]},
+            {'role': 'user', 'content': prompt},
+            {'role': 'assistant', 'content': response},
         ], {}
 
 

--- a/align_anything/configs/template.py
+++ b/align_anything/configs/template.py
@@ -68,9 +68,17 @@ class ChatTemplate:
             multi_modal_info,
         )
 
-    def format_prompt_only_sample(self, raw_sample: dict[str, Any]) -> tuple[str, Any]:
+    def format_prompt_only_sample(self, raw_sample: dict[str, Any], apply_chat_template: bool = True) -> tuple[str, Any]:
         raw_prompt, multi_modal_info = self.dataset_formatter.format_prompt_only_sample(raw_sample)
-        return self.model_formatter(raw_prompt, add_generation_prompt=True), multi_modal_info
+        if apply_chat_template:
+            return self.model_formatter(raw_prompt, add_generation_prompt=True), multi_modal_info
+        else:
+            if isinstance(raw_prompt[0]['content'], list):
+                return raw_prompt[0]['content'][0]['text'], multi_modal_info
+            elif isinstance(raw_prompt[0]['content'], str):
+                return raw_prompt[0]['content'], multi_modal_info
+            else:
+                raise ValueError(f"Unknown format for raw_prompt: {raw_prompt}")
 
     def format_unmatched_supervised_sample(
         self, raw_sample_for_prompt: dict[str, Any], raw_sample_for_response: dict[str, Any]

--- a/align_anything/configs/train/text_to_text/ppo_vllm.yaml
+++ b/align_anything/configs/train/text_to_text/ppo_vllm.yaml
@@ -22,7 +22,7 @@ train_cfgs:
   # Seed for random number generator
   seed: 42
   # Batch size per device for data generation
-  per_device_prompt_batch_size: 1
+  per_device_prompt_batch_size: 64
   # Batch size per device for training
   per_device_train_batch_size: 1
   # Batch size per device for evauation
@@ -188,3 +188,21 @@ bnb_cfgs:
   bnb_4bit_compute_dtype: float16
 # Customized special tokens
 special_tokens: null
+# The vLLM configurations
+vllm_cfgs:
+  # Whether to use vLLM
+  use_vllm: True
+  # The number of vLLM engines
+  vllm_num_engines: 1
+  # The tensor parallel size for vLLM
+  vllm_tensor_parallel_size: 1
+  # Whether to enable prefix caching in vLLM
+  vllm_enable_prefix_caching: True
+  # Whether to enforce eager execution in vLLM
+  vllm_enforce_eager: True
+  # The maximum model length for vLLM
+  vllm_max_model_len: 2048
+  # The GPU memory utilization for vLLM
+  vllm_gpu_memory_utilization: 0.9
+  # Whether to enable sleep mode in vLLM
+  vllm_enable_sleep: False

--- a/align_anything/datasets/text_to_text/prompt_only.py
+++ b/align_anything/datasets/text_to_text/prompt_only.py
@@ -74,12 +74,14 @@ class PromptOnlyDataset(Dataset):
         split: str | None = None,
         data_files: str | None = None,
         optional_args: list | str = [],
+        apply_chat_template: bool = True,
     ):
         super().__init__()
         assert path, f'You must set the valid datasets path! Here is {path}'
         assert template, f'You must set the valid template path! Here is {template}'
         self.tokenizer = tokenizer
         self.processor = processor
+        self.apply_chat_template = apply_chat_template
         if path.endswith('json'):
             import json
 
@@ -105,7 +107,7 @@ class PromptOnlyDataset(Dataset):
 
     def preprocess(self, raw_sample: dict[str, Any]) -> PromptOnlySample:
         return_dict = {}
-        raw_text, _ = self.template.format_prompt_only_sample(raw_sample)
+        raw_text, _ = self.template.format_prompt_only_sample(raw_sample, apply_chat_template=self.apply_chat_template)
         if raw_text[-1] != self.tokenizer.eos_token:
             raw_text += self.tokenizer.eos_token
         return_dict['input_ids'] = self.tokenize(raw_text)

--- a/align_anything/trainers/text_to_text/ppo.py
+++ b/align_anything/trainers/text_to_text/ppo.py
@@ -199,7 +199,11 @@ class PPOTrainer(RLTrainerBase):  # pylint: disable=too-many-instance-attributes
         """Split a batch of PTX samples into micro-batches."""
         micro_batches = []
         micro_batch = self.infer_batch(ptx_batch)
-        micro_batches.append(micro_batch)
+        for batch_idx in range(0, micro_batch['input_ids'].size(0)):
+            micro_batch = {}
+            for key, value in ptx_batch.items():
+                micro_batch[key] = value[batch_idx: batch_idx + 1, :]
+            micro_batches.append(micro_batch)
         return micro_batches
 
     def actor_step(self, mini_prompt_only_batch: PromptOnlyBatch) -> dict[str, Any]:
@@ -456,8 +460,7 @@ class PPOTrainer(RLTrainerBase):  # pylint: disable=too-many-instance-attributes
                         progress_bar.update(1)
 
                         save_interval = (
-                            self.cfgs.train_cfgs.epochs
-                            * len(self.prompt_only_dataloader)
+                            self.total_update_steps
                             // self.cfgs.logger_cfgs.save_total_limit
                         )
 

--- a/align_anything/trainers/text_to_text/ppo_vllm.py
+++ b/align_anything/trainers/text_to_text/ppo_vllm.py
@@ -1,0 +1,473 @@
+# Copyright 2025 PKU-Alignment Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Trainer for PPO training with vLLM generation."""
+
+
+import argparse
+import copy
+import itertools
+import os
+import sys
+from typing import Any
+
+import ray
+
+import deepspeed
+import torch
+import torch.distributed as dist
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+from tqdm import tqdm
+
+from align_anything.configs.template import ChatTemplate
+from align_anything.datasets import DummyDataset
+from align_anything.utils.multi_process import is_main_process
+
+
+from align_anything.datasets.text_to_text import (
+    PromptOnlyBatch,
+    PromptOnlyDataset,
+    SupervisedDataset,
+)
+
+from align_anything.trainers.text_to_text.ppo import PPOTrainer
+from align_anything.utils.vllm_utils.config import VLLMConfig
+
+from align_anything.utils.device_utils import get_current_device, torch_gc, torch_set_device
+from align_anything.utils.multi_process import (
+    get_current_device,
+    is_main_process,
+)
+from align_anything.utils.tools import (
+    custom_cfgs_to_dict,
+    dict_to_namedtuple,
+    gather_log_probabilities,
+    read_cfgs,
+    seed_everything,
+    update_dict,
+)
+
+from align_anything.utils.vllm_utils.vllm_sampling import generate_with_vllm
+
+from vllm.utils import get_ip, get_open_port
+
+
+def get_physical_gpu_id():
+    import torch
+
+    device = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device)
+    return str(props.uuid)
+
+class PPOVLLMTrainer(PPOTrainer):
+
+    def init_datasets(self) -> None:
+        """Initialize training and evaluation datasets."""
+        # load training datasets
+        self.prompt_only_dataloader, self.ptx_dataloader = (
+            self.get_main_process_prompt_only_dataloader(PromptOnlyDataset, SupervisedDataset)
+        )
+        print('rank', dist.get_rank(), 'prompt_only_dataloader', len(self.prompt_only_dataloader))
+
+    def init_models(self):
+        # Call the original init_models method
+        super().init_models()
+        vllm_devices = os.environ.get('VLLM_DEVICES')
+        num_actors = len(vllm_devices.split(','))
+        current_rank = dist.get_rank()
+        is_main_process = current_rank == 0
+        # Initialize vLLM if enabled
+        self.vllm_config = getattr(self.cfgs, 'vllm_cfgs', VLLMConfig())
+        self.use_vllm = getattr(self.vllm_config, 'use_vllm', False)
+        self.first_actor_init = True
+        
+        if self.use_vllm and is_main_process:
+            try:
+                import ray
+                original_cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+                os.environ["CUDA_VISIBLE_DEVICES"] = vllm_devices
+                from align_anything.utils.vllm_utils.vllm_engine import create_vllm_engines
+                
+                # Initialize Ray if not already initialized
+                if not ray.is_initialized():
+                    ray.init(ignore_reinit_error=True)
+                
+                # Create vLLM engines
+                vllm_max_model_len = self.vllm_config.vllm_max_model_len or self.cfgs.model_cfgs.model_max_length
+                
+                self.vllm_engines = create_vllm_engines(
+                    num_engines=self.vllm_config.vllm_num_engines,
+                    tensor_parallel_size=self.vllm_config.vllm_tensor_parallel_size,
+                    pretrain=self.cfgs.model_cfgs.actor_model_name_or_path,
+                    seed=self.cfgs.train_cfgs.seed,
+                    enable_prefix_caching=self.vllm_config.vllm_enable_prefix_caching,
+                    enforce_eager=self.vllm_config.vllm_enforce_eager,
+                    max_model_len=vllm_max_model_len,
+                    num_total_actors=num_actors,
+                    gpu_memory_utilization=self.vllm_config.vllm_gpu_memory_utilization,
+                    vllm_enable_sleep=self.vllm_config.vllm_enable_sleep,
+                )
+
+                refs = [engine.init_process_group.remote(
+                    master_address=get_ip(),
+                    master_port=get_open_port(),
+                    rank_offset=current_rank,
+                    world_size=num_actors,
+                    group_name="vllm_group",
+                    backend="nccl",
+                    use_ray=False,
+                ) for engine in self.vllm_engines]
+                ray.get(refs)
+
+                if is_main_process:
+                    print(f"Initialized {len(self.vllm_engines)} vLLM engines for accelerated sampling")
+                os.environ["CUDA_VISIBLE_DEVICES"] = original_cuda_visible_devices
+            except ImportError:
+                print("vLLM or Ray not available. Falling back to standard generation.")
+                self.use_vllm = False
+                self.vllm_engines = None
+        else:
+            self.vllm_engines = None
+
+    def actor_step(self, prompt_only_batch: PromptOnlyBatch):
+        infer_batch = self.infer_batch(prompt_only_batch)
+        actor_batch = copy.deepcopy(infer_batch)
+        actor_batch['prompt_ids'] = prompt_only_batch['input_ids'].contiguous()
+
+        original_cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+        vllm_devices = os.environ.get('VLLM_DEVICES')
+        os.environ["CUDA_VISIBLE_DEVICES"] = vllm_devices
+        
+        # Extract prompts from the batch
+        input_ids = infer_batch.get('input_ids')
+        batch_attention_mask = infer_batch.get('attention_mask')
+        
+        # Decode prompts
+        prompts = []
+        for i in range(input_ids.size(0)):
+            mask = batch_attention_mask[i].bool()
+            prompt_ids = input_ids[i, mask]
+            prompt = self.tokenizer.decode(prompt_ids, skip_special_tokens=True)
+            prompts.append(prompt)
+        print('generating with vllm...')
+
+        # Generate with vLLM on main process using VLLM_DEVICES
+        sequences, attention_mask = generate_with_vllm(
+            prompts=prompts,
+            tokenizer=self.tokenizer,
+            vllm_engines=self.vllm_engines,
+            n_samples_per_prompt=1,
+            temperature=self.cfgs.model_cfgs.temperature,
+            top_p=self.cfgs.model_cfgs.top_p,
+            top_k=-1,
+            max_new_tokens=self.cfgs.model_cfgs.max_new_tokens,
+            min_new_tokens=1,
+            skip_special_tokens=False,
+        )
+        
+        print(f"Successfully generated with vLLM on main process")
+        os.environ["CUDA_VISIBLE_DEVICES"] = original_cuda_visible_devices
+        self.first_actor_init = False
+        
+        # Update actor batch with the broadcast results
+        actor_batch['input_ids'] = sequences
+        actor_batch['attention_mask'] = attention_mask
+        
+        return actor_batch
+
+    def get_main_process_prompt_only_dataloader(
+        self,
+        train_data_dtype,
+        ptx_data_dtype,
+    ) -> tuple[DataLoader, DataLoader | None, DataLoader]:
+        """Get the dataloaders based on data_dtype."""
+        formatter = self.processor if self.processor else self.tokenizer
+        custom_formatter = (
+            self.actor_model.apply_chat_template
+            if hasattr(self.actor_model, 'apply_chat_template')
+            else None
+        )
+        self.train_template = ChatTemplate(
+            formatter, self.cfgs.data_cfgs.train_template, custom_formatter
+        )
+        self.eval_template = None
+
+        if is_main_process():
+            train_dataset = train_data_dtype(
+                path=self.cfgs.data_cfgs.train_datasets,
+                template=self.train_template,
+                tokenizer=self.tokenizer,
+                processor=self.processor,
+                name=self.cfgs.data_cfgs.train_name,
+                size=self.cfgs.data_cfgs.train_size,
+                split=self.cfgs.data_cfgs.train_split,
+                data_files=self.cfgs.data_cfgs.train_data_files,
+                optional_args=self.cfgs.data_cfgs.train_optional_args,
+            )
+            dataset_length = len(train_dataset)
+            train_dataloader = DataLoader(
+                train_dataset,
+                collate_fn=train_dataset.get_collator(),
+                shuffle=True,
+                batch_size=int(self.cfgs.train_cfgs.per_device_prompt_batch_size),
+            )
+        else:
+            dataset_length = 0
+
+        dist.barrier()
+        torch.cuda.synchronize()
+
+        # Broadcast the dataset length to all processes
+        dataset_length_tensor = torch.tensor([dataset_length], dtype=torch.int64, device=get_current_device())
+        dist.broadcast(dataset_length_tensor, src=0)
+        dataset_length = dataset_length_tensor.item()
+        if not is_main_process():
+            # Create a dummy dataset with the received length
+            train_dataloader = DataLoader(DummyDataset(dataset_length))
+
+        # load ptx datasets
+        self.use_ptx = self.cfgs.data_cfgs.ptx_datasets is not None
+        if self.use_ptx:
+            custom_formatter = (
+                self.actor_model.apply_chat_template
+                if hasattr(self.actor_model, 'apply_chat_template')
+                else None
+            )
+            self.ptx_template = ChatTemplate(
+                formatter, self.cfgs.data_cfgs.ptx_template, custom_formatter
+            )
+            ptx_dataset = ptx_data_dtype(
+                path=self.cfgs.data_cfgs.ptx_datasets,
+                template=self.ptx_template,
+                tokenizer=self.tokenizer,
+                processor=self.processor,
+                name=self.cfgs.data_cfgs.ptx_name,
+                size=self.cfgs.data_cfgs.ptx_size,
+                split=self.cfgs.data_cfgs.ptx_split,
+                data_files=self.cfgs.data_cfgs.ptx_data_files,
+                optional_args=self.cfgs.data_cfgs.ptx_optional_args,
+            )
+            ptx_dataloader = DataLoader(
+                ptx_dataset,
+                collate_fn=ptx_dataset.get_collator(),
+                sampler=DistributedSampler(ptx_dataset, shuffle=True),
+                batch_size=int(self.cfgs.train_cfgs.per_device_prompt_batch_size),
+            )
+        else:
+            ptx_dataloader = DataLoader(DummyDataset(len(train_dataloader)))
+
+
+        return train_dataloader, ptx_dataloader
+
+
+    @torch.no_grad()
+    def rollout(self, actor_batch: PromptOnlyBatch) -> list[dict[str, Any]]:
+        """Rollout a batch of experiences."""
+        # freeze the model for rolling out
+
+        total_batch_size = actor_batch['input_ids'].size(0)
+        micro_batch_size = int(self.cfgs.train_cfgs.per_device_train_batch_size)
+        micro_inference_batches = []
+        micro_training_batches = []
+        mini_batch = {}
+        for i in tqdm(range(0, total_batch_size, micro_batch_size), desc='Scoring batches and generating logprobs...', disable=not is_main_process()):
+
+            mini_batch = {
+                key: actor_batch[key][i : i + micro_batch_size] for key in actor_batch
+            }
+            # reward model and reward critic model scoring
+            reward_batch = self.reward_model_step(mini_batch)
+            # calculate the log probabilities
+            logits = self.actor_model(**mini_batch).logits
+            ref_logits = self.actor_reference_model(**mini_batch).logits
+            log_probs = gather_log_probabilities(logits[:, :-1], mini_batch['input_ids'][:, 1:])
+            ref_log_probs = gather_log_probabilities(
+                ref_logits[:, :-1], mini_batch['input_ids'][:, 1:]
+            )
+
+            micro_training_batch = {}
+            micro_training_batch['prompt_idx'] = mini_batch['prompt_ids'].size(-1) - 1
+            micro_training_batch['log_probs'] = log_probs
+            micro_training_batch['ref_log_probs'] = ref_log_probs
+            micro_training_batch['reward'] = reward_batch['reward']
+            micro_training_batch['reward_values'] = reward_batch['reward_values']
+
+            mini_batch['input_ids'] = reward_batch['input_ids']
+            # add rollout results to the batches
+            micro_inference_batches.append(mini_batch)
+            micro_training_batches.append(micro_training_batch)
+
+        # unfreeze the model for training
+        self.set_train()
+
+        return micro_inference_batches, micro_training_batches
+
+
+    def broadcast_batch(self, batch: dict[str, torch.Tensor], keys: list[str], dtypes: list[torch.dtype]) -> None:
+        """Broadcast the batch to all processes."""
+        for i, key in enumerate(keys):
+            if is_main_process():
+                tensor_shape = torch.tensor(batch[key].shape, dtype=torch.long, device=get_current_device())
+            else:
+                tensor_shape = torch.zeros(2, dtype=torch.long, device=get_current_device())
+
+            dist.broadcast(tensor_shape, src=0)
+
+            if not is_main_process():
+                batch[key] = torch.zeros(tensor_shape.tolist(), dtype=dtypes[i], device=get_current_device())
+
+            dist.broadcast(batch[key], src=0)
+
+    def update_vllm_engines(self):
+        """Update the weights of the vLLM engines."""
+        torch_gc()
+        model = self.actor_model.module
+        count, num_params = 0, len(list(model.named_parameters()))
+        if is_main_process():
+            print(f"Updating vLLM engines...")
+        for name, param in model.named_parameters():
+            count += 1  # empty_cache at last param
+            # Fire all vllm engines for broadcast
+            if is_main_process():
+                shape = param.shape if self.ds_train_cfgs['zero_optimization']['stage'] == 3 else param.ds_shape
+                refs = [
+                    engine.update_weight.remote(
+                        name, dtype=param.dtype, shape=shape, empty_cache=count == num_params
+                    )
+                    for engine in self.vllm_engines
+                ]
+                ray.get(refs)
+
+        if is_main_process():
+            print(f"Updated vLLM engines for generating next batch.")
+
+        torch_gc()
+        torch.distributed.barrier()
+        torch.cuda.synchronize()
+        
+    def train(self) -> None:
+        """Train the model."""
+        self.logger.print('***** Running training *****')
+        progress_bar = tqdm(
+            total=self.total_training_steps,
+            desc=f'Training 1/{self.cfgs.train_cfgs.epochs} epoch',
+            position=0,
+            leave=True,
+            disable=not is_main_process(),
+        )
+
+        if self.cfgs.data_cfgs.eval_datasets:
+            self.logger.print('\n***** Evaluating at the beginning *****')
+            self.eval()
+
+        num_prompt_only_batches = len(self.prompt_only_dataloader) * self.cfgs.train_cfgs.per_device_prompt_batch_size
+        num_ptx_batches = len(self.ptx_dataloader)
+        num_ptx_replicas = (num_prompt_only_batches + num_ptx_batches - 1) // num_ptx_batches
+
+        for epoch in range(int(self.cfgs.train_cfgs.epochs)):
+
+            for prompt_only_batch, ptx_batch in zip(
+                self.prompt_only_dataloader,
+                itertools.chain.from_iterable([self.ptx_dataloader] * num_ptx_replicas),
+            ):
+                self.set_train(mode=False)
+                
+                if is_main_process():
+                    actor_batch = self.actor_step(prompt_only_batch)
+                    print('Actor batch has been generated')
+                else:
+                    actor_batch = {
+                        'prompt_ids': None,
+                        'input_ids': None,
+                        'attention_mask': None
+                    }
+                
+                if dist.is_initialized():
+                    
+                    self.broadcast_batch(
+                        actor_batch, 
+                        ['prompt_ids', 'input_ids', 'attention_mask'], 
+                        [torch.long, torch.long, torch.bool]
+                    )
+                
+                dist.barrier()
+                torch.cuda.synchronize()
+                torch_gc()
+                inference_batches, training_batches = self.rollout(actor_batch)
+                if self.use_ptx:
+                    ptx_batches = self.split_ptx_micro_batches(ptx_batch)
+                else:
+                    ptx_batches = [None for _ in range(len(inference_batches))]
+
+                for _ in range(self.cfgs.train_cfgs.update_iters):
+                    for idx in tqdm(range(len(inference_batches)), desc='Updating PPO with the scored batches...', disable=not is_main_process()):
+                        inference_batch = inference_batches[idx]
+                        training_batch = training_batches[idx]
+                        ptx_batch = ptx_batches[idx]
+                        rl_info = self.rl_step(inference_batch, training_batch)
+                        torch_gc()
+
+                        if self.use_ptx:
+                            ptx_info = self.ptx_step(ptx_batch)
+                            torch_gc()
+                            self.logger.log(ptx_info, step=self.global_step)
+
+                        # update the actor model weights for generating next batch
+                        self.logger.log(rl_info, step=self.global_step)
+
+                        save_interval = self.total_update_steps // self.cfgs.logger_cfgs.save_total_limit
+                        self.global_step += 1
+                        if self.global_step % save_interval == 0:
+                            self.logger.print(f'Saving checkpoint at step {self.global_step} ...')
+                            self.save(tag=self.global_step)
+                            self.logger.print('Checkpoint saved.')
+
+                self.update_vllm_engines()
+                progress_bar.set_description(
+                    f'Training {epoch + 1}/{self.cfgs.train_cfgs.epochs} epoch '
+                    f'(reward {rl_info["train/reward"]:.4f})',
+                )
+                progress_bar.update(1)
+
+def main():
+    # setup distribution training
+    deepspeed.init_distributed()
+    current_device = get_current_device()
+    torch_set_device(current_device)
+
+    # read default configs from the yaml file
+    task = os.path.join('text_to_text', 'ppo_vllm')
+    dict_cfgs, ds_cfgs = read_cfgs(mode='train', task=task)
+
+    # get custom configs from command line
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    _, unparsed_args = parser.parse_known_args()
+    keys = [k[2:] for k in unparsed_args[1::2]]
+    values = list(unparsed_args[2::2])
+    unparsed_args = dict(zip(keys, values))
+    for k, v in unparsed_args.items():
+        dict_cfgs = update_dict(dict_cfgs, custom_cfgs_to_dict(k, v))
+
+    # setup training
+    cfgs = dict_to_namedtuple(dict_cfgs)
+    seed_everything(cfgs.train_cfgs.seed)
+
+    trainer = PPOVLLMTrainer(cfgs=cfgs, ds_cfgs=ds_cfgs)
+    trainer.train()
+    trainer.save()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/align_anything/utils/vllm_utils/__init__.py
+++ b/align_anything/utils/vllm_utils/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2025 PKU-Alignment Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""vLLM utilities for accelerated sampling."""
+
+from align_anything.utils.vllm_utils.vllm_engine import create_vllm_engines, batch_vllm_engine_call
+from align_anything.utils.vllm_utils.vllm_sampling import generate_with_vllm
+
+__all__ = ['create_vllm_engines', 'batch_vllm_engine_call', 'generate_with_vllm']

--- a/align_anything/utils/vllm_utils/config.py
+++ b/align_anything/utils/vllm_utils/config.py
@@ -1,0 +1,47 @@
+# Copyright 2025 PKU-Alignment Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Configuration for vLLM integration."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class VLLMConfig:
+    """Configuration for vLLM integration."""
+    
+    use_vllm: bool = False
+    """Whether to use vLLM for accelerated sampling."""
+    
+    vllm_num_engines: int = 1
+    """Number of vLLM engines to create."""
+    
+    vllm_tensor_parallel_size: int = 1
+    """Tensor parallel size for vLLM."""
+    
+    vllm_enable_prefix_caching: bool = True
+    """Whether to enable prefix caching in vLLM."""
+    
+    vllm_enforce_eager: bool = True
+    """Whether to enforce eager execution in vLLM."""
+    
+    vllm_max_model_len: Optional[int] = None
+    """Maximum model length for vLLM. If None, use model_max_length."""
+    
+    vllm_gpu_memory_utilization: float = 0.9
+    """GPU memory utilization for vLLM."""
+    
+    vllm_enable_sleep: bool = False
+    """Whether to enable sleep mode in vLLM."""

--- a/align_anything/utils/vllm_utils/vllm_engine.py
+++ b/align_anything/utils/vllm_utils/vllm_engine.py
@@ -1,0 +1,250 @@
+# Copyright 2025 PKU-Alignment Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""vLLM engine implementation for accelerated sampling."""
+
+import os
+from collections import defaultdict
+import queue
+from typing import Any, List
+
+import ray
+from ray.util.placement_group import placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+import torch.distributed as dist
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def ray_noset_visible_devices():
+    """Check if RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set."""
+    return os.environ.get("RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES", "0") == "1"
+
+
+@ray.remote
+def get_all_env_variables():
+    """Get all environment variables."""
+    import os
+    return os.environ
+
+
+@ray.remote
+class LLMRayActor:
+    """Ray actor for vLLM engine."""
+
+    def __init__(self, *args, bundle_indices: list = None, **kwargs):
+        noset_visible_devices = kwargs.pop("noset_visible_devices")
+        if kwargs.get("distributed_executor_backend") == "ray":
+            # a hack to make the script work.
+            # stop ray from manipulating CUDA_VISIBLE_DEVICES
+            # at the top-level when the distributed_executor_backend is ray.
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        elif noset_visible_devices:
+            # We need to set CUDA_VISIBLE_DEVICES to the ray assigned GPU
+            # when the distributed_executor_backend is not ray and
+            # RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set.
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(ray.get_gpu_ids()[0])
+
+        num_gpus = kwargs.pop("num_gpus")
+        if bundle_indices is not None:
+            os.environ["VLLM_RAY_PER_WORKER_GPUS"] = str(num_gpus)
+            os.environ["VLLM_RAY_BUNDLE_INDICES"] = ",".join(map(str, bundle_indices))
+            print(f"creating LLM with bundle_indices={bundle_indices}")
+
+        # Number of actors that will send prompt to this engine
+        self.num_actors = kwargs.pop("num_actors")
+        self.actor_counter = 0
+        self.requests = {}
+        self.response_queues = defaultdict(queue.Queue)
+
+        # Import vLLM here to avoid early import
+        from vllm import LLM
+        self.llm = LLM(*args, **kwargs)
+
+    def init_process_group(self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray):
+        return self.llm.collective_rpc(
+            "init_process_group",
+            args=(master_address, master_port, rank_offset, world_size, group_name, backend, use_ray),
+        )
+
+    def update_weight(self, name, dtype, shape, empty_cache=False):
+        return self.llm.collective_rpc("update_weight", args=(name, dtype, shape, empty_cache))
+
+    def update_weight_cuda_ipc(self, name, dtype, shape, ipc_handles, empty_cache=False):
+        return self.llm.collective_rpc("update_weight_cuda_ipc", args=(name, dtype, shape, ipc_handles, empty_cache))
+
+    def reset_prefix_cache(self):
+        self.llm.llm_engine.reset_prefix_cache()
+
+    def sleep(self, level=1):
+        self.llm.sleep(level=level)
+
+    def wake_up(self):
+        self.llm.wake_up()
+
+    def add_requests(self, actor_rank, *, sampling_params, prompts):
+        """
+        Save the requests from actors and generate responses when all actors have sent their requests
+        """
+        self.requests[actor_rank] = prompts
+        self.actor_counter += 1
+        if self.actor_counter == self.num_actors:
+            assert len(self.requests) == self.num_actors
+            num_requests = []
+            requests = []
+            for actor_rank, request in self.requests.items():
+                num_requests.append((actor_rank, len(request)))
+                requests.extend(request)
+
+            if len(requests) > 0:
+                # For now we assume that all requests have the same sampling params
+                responses = self.llm.chat(messages=requests, sampling_params=sampling_params, add_generation_prompt=True)
+            else:
+                responses = []
+
+            offset = 0
+            self.responses = {}
+            for actor_rank, num in num_requests:
+                self.response_queues[actor_rank].put(responses[offset : offset + num])
+                offset += num
+
+            self.actor_counter = 0
+            self.requests = {}
+
+    def get_responses(self, actor_rank):
+        """
+        Return the responses for the actor with the given rank
+        """
+        return self.response_queues[actor_rank].get()
+
+
+def create_vllm_engines(
+    num_engines: int,
+    tensor_parallel_size: int,
+    pretrain: str,
+    seed: int,
+    enable_prefix_caching: bool,
+    enforce_eager: bool,
+    max_model_len: int,
+    num_total_actors: int,
+    shared_pg=None,
+    gpu_memory_utilization=None,
+    vllm_enable_sleep=False,
+):
+    """Create vLLM engines.
+    
+    Args:
+        num_engines: Number of vLLM engines to create.
+        tensor_parallel_size: Tensor parallel size.
+        pretrain: Path to pretrained model.
+        seed: Random seed.
+        enable_prefix_caching: Whether to enable prefix caching.
+        enforce_eager: Whether to enforce eager execution.
+        max_model_len: Maximum model length.
+        num_total_actors: Total number of actors.
+        shared_pg: Shared placement group.
+        gpu_memory_utilization: GPU memory utilization.
+        vllm_enable_sleep: Whether to enable sleep mode.
+        
+    Returns:
+        List of vLLM engines.
+    """
+    import vllm
+
+    assert vllm.__version__ >= "0.7.2", "Only supports vllm >= 0.7.2"
+
+    vllm_engines = []
+    distributed_executor_backend = "uni" if tensor_parallel_size == 1 else "ray"
+    use_hybrid_engine = shared_pg is not None
+    num_gpus = int(tensor_parallel_size == 1)
+    if use_hybrid_engine and tensor_parallel_size == 1:
+        # every worker will use 0.2 GPU, so that we can schedule
+        # 2 instances on the same GPUs.
+        num_gpus = 0.2
+
+    if not use_hybrid_engine:
+        # Create a big placement group to ensure that all engines are packed
+        bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_engines * tensor_parallel_size)]
+        shared_pg = placement_group(bundles, strategy="PACK")
+        ray.get(shared_pg.ready())
+
+    for i in range(num_engines):
+        bundle_indices = None
+        if tensor_parallel_size > 1:
+            bundle_indices = list(range(i * tensor_parallel_size, (i + 1) * tensor_parallel_size))
+
+        scheduling_strategy = PlacementGroupSchedulingStrategy(
+            placement_group=shared_pg,
+            placement_group_capture_child_tasks=True,
+            placement_group_bundle_index=i * tensor_parallel_size,
+        )
+
+        if num_engines >= num_total_actors:
+            num_actors = 1
+        else:
+            num_actors = num_total_actors // num_engines + int(i < num_total_actors % num_engines)
+
+        vllm_engines.append(
+            LLMRayActor.options(
+                num_cpus=num_gpus,
+                num_gpus=num_gpus,
+                scheduling_strategy=scheduling_strategy,
+            ).remote(
+                model=pretrain,
+                enforce_eager=enforce_eager,
+                worker_cls="align_anything.utils.vllm_utils.vllm_worker_wrap.WorkerWrap",
+                tensor_parallel_size=tensor_parallel_size,
+                seed=seed + i,
+                distributed_executor_backend=distributed_executor_backend,
+                max_model_len=max_model_len,
+                enable_prefix_caching=enable_prefix_caching,
+                dtype="bfloat16",
+                trust_remote_code=True,
+                num_actors=num_actors,
+                gpu_memory_utilization=gpu_memory_utilization,
+                bundle_indices=bundle_indices,
+                num_gpus=0.2 if use_hybrid_engine else 1,
+                enable_sleep_mode=vllm_enable_sleep,
+                noset_visible_devices=ray_noset_visible_devices(),
+            )
+        )
+
+    if vllm_enable_sleep:
+        batch_vllm_engine_call(vllm_engines, "sleep", rank_0_only=False)
+
+    return vllm_engines
+
+
+def batch_vllm_engine_call(engines: List[Any], method_name: str, *args, rank_0_only: bool = True, **kwargs):
+    """
+    Batch call a method on multiple vLLM engines.
+    Args:
+        engines: List of vLLM engine instances
+        method_name: Name of the method to call
+        rank_0_only: Only execute on rank 0 if True
+        *args: Positional arguments to pass to the method
+        **kwargs: Keyword arguments to pass to the method
+    Returns:
+        List of results from ray.get() if on rank 0, None otherwise
+    """
+    if rank_0_only and dist.get_rank() != 0:
+        return None
+
+    refs = []
+    for engine in engines:
+        method = getattr(engine, method_name)
+        refs.append(method.remote(*args, **kwargs))
+
+    return ray.get(refs)

--- a/align_anything/utils/vllm_utils/vllm_sampling.py
+++ b/align_anything/utils/vllm_utils/vllm_sampling.py
@@ -1,0 +1,143 @@
+# Copyright 2025 PKU-Alignment Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""vLLM sampling implementation for accelerated text generation."""
+
+import time
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import ray
+import torch
+import torch.distributed as dist
+from vllm import SamplingParams
+import logging
+from align_anything.utils.tools import right_padding
+
+logger = logging.getLogger(__name__)
+
+
+def generate_with_vllm(
+    prompts: List[str],
+    tokenizer,
+    vllm_engines: List,
+    n_samples_per_prompt: int = 1,
+    temperature: float = 1.0,
+    top_p: float = 1.0,
+    top_k: int = -1,
+    max_new_tokens: int = 1024,
+    min_new_tokens: int = 1,
+    skip_special_tokens: bool = False,
+    **kwargs
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Generate text using vLLM.
+    
+    Args:
+        prompts: List of prompts to generate from.
+        tokenizer: Tokenizer to use.
+        vllm_engines: List of vLLM engines.
+        n_samples_per_prompt: Number of samples to generate per prompt.
+        max_length: Maximum length of generated text.
+        temperature: Temperature for sampling.
+        top_p: Top-p for sampling.
+        top_k: Top-k for sampling.
+        max_new_tokens: Maximum number of new tokens to generate.
+        min_new_tokens: Minimum number of new tokens to generate.
+        skip_special_tokens: Whether to skip special tokens.
+        **kwargs: Additional arguments.
+        
+    Returns:
+        Tuple of (sequences, attention_mask, action_mask).
+    """
+    # round-robin load balance
+    rank = dist.get_rank()
+
+    llms = [vllm_engines[0]]
+
+    print('creating sampling params...')
+
+    sampling_params = SamplingParams(
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        max_tokens=max_new_tokens,
+        min_tokens=min_new_tokens,
+        skip_special_tokens=skip_special_tokens,
+        include_stop_str_in_output=True,
+    )
+
+    # Expand prompt list based on the number of samples per prompt
+    all_raw_prompts = sum([[prompt] * n_samples_per_prompt for prompt in prompts], [])
+
+    all_prompts = []
+    for raw_prompt in all_raw_prompts:
+        all_prompts.append([{'role': 'user', 'content': raw_prompt}])
+
+    print('distributing requests to engines...')
+
+    # Distribute requests to engines and collect responses to outputs
+    refs = []
+    batch_size = (len(all_prompts) + len(llms) - 1) // len(llms)
+    for i, llm in enumerate(llms):
+        prompts = all_prompts[i * batch_size : (i + 1) * batch_size]
+        refs.append(
+            llm.add_requests.remote(rank, sampling_params=sampling_params, prompts=prompts)
+        )
+    ray.get(refs)
+
+    # Retrieve and combine results from all outputs
+    all_output_refs = []
+    for i, llm in enumerate(llms):
+        all_output_refs.append(llm.get_responses.remote(rank))
+    all_outputs = sum(ray.get(all_output_refs), [])
+    # Process outputs in micro batches
+    all_sequences = []
+    all_attention_masks = []
+    max_input_len, max_output_len = 0, 0
+    pad_token_id, eos_token_id = tokenizer.pad_token_id, tokenizer.eos_token_id
+
+    print('all_outputs', len(all_outputs)) # 32 1
+    
+    for i in range(0, len(all_outputs)):
+        current_outputs = all_outputs[i]
+        max_input_len = max(max_input_len, len(current_outputs.prompt_token_ids))
+        max_output_len = max(max_output_len, len(current_outputs.outputs[0].token_ids))
+
+    for i in range(0, len(all_outputs)):
+        current_outputs = all_outputs[i]
+        response = current_outputs.outputs[0]
+        
+        # left padding input
+        input_len = len(current_outputs.prompt_token_ids)
+        input_ids = [pad_token_id] * (max_input_len - input_len) + list(current_outputs.prompt_token_ids)
+
+        # right padding output
+        output_len = len(response.token_ids)
+        output_ids = list(response.token_ids) + [pad_token_id] * (max_output_len - output_len)
+
+        # concat input and output
+        sequences = torch.tensor(input_ids + output_ids, device="cuda").unsqueeze(0)
+        
+        # Create attention mask (1 for tokens, 0 for padding)
+        attention_mask = torch.logical_and(sequences.ne(pad_token_id), sequences.ne(eos_token_id)).long()
+        
+        all_sequences.append(sequences)
+        all_attention_masks.append(attention_mask)
+        
+    if all_sequences:
+        sequences = torch.cat(all_sequences, dim=0).to(torch.long)
+        attention_mask = torch.cat(all_attention_masks, dim=0).to(torch.bool)
+        return sequences, attention_mask
+    else:
+        # Return empty tensors if no outputs
+        return torch.tensor([], device="cuda", dtype=torch.long), torch.tensor([], device="cuda", dtype=torch.bool)

--- a/align_anything/utils/vllm_utils/vllm_worker_wrap.py
+++ b/align_anything/utils/vllm_utils/vllm_worker_wrap.py
@@ -1,0 +1,88 @@
+# Copyright 2025 PKU-Alignment Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""vLLM worker wrapper for model weight updates."""
+
+import torch
+from vllm.worker.worker import Worker
+from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+from vllm.distributed.utils import StatelessProcessGroup
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_physical_gpu_id():
+    """Get the physical GPU ID."""
+    if not torch.cuda.is_available():
+        return -1
+    return torch.cuda.current_device()
+
+
+class WorkerWrap(Worker):
+    """Worker wrapper for vLLM."""
+
+    def init_process_group(
+        self, master_address, master_port, rank_offset, world_size, group_name, backend="nccl", use_ray=False
+    ):
+        """Init torch process group for model weights update"""
+        assert torch.distributed.is_initialized(), f"default torch process group must be initialized"
+        assert group_name != "", f"group name must not be empty"
+
+        rank = torch.distributed.get_rank() + rank_offset
+        if use_ray:
+            import ray.util.collective as collective
+
+            collective.init_collective_group(world_size=world_size, rank=rank, backend=backend, group_name=group_name)
+            self._model_update_group = group_name
+        else:
+            self._model_update_group = self._init_process_group(
+                master_address=master_address,
+                master_port=master_port,
+                world_size=world_size,
+                rank=rank,
+            )
+        self._model_update_with_ray = use_ray
+        logger.info(
+            f"init_process_group: master_address={master_address}, master_port={master_port}, "
+            f"rank={rank}, world_size={world_size}, group_name={group_name}"
+        )
+
+    def _init_process_group(self, master_address, master_port, world_size, rank):
+        """Initialize process group."""
+        # Create a new process group
+        pg = StatelessProcessGroup.create(
+            host=master_address,
+            port=master_port,
+            rank=rank,
+            world_size=world_size,
+        )
+        pynccl = PyNcclCommunicator(pg, device=self.device)
+        return pynccl
+
+    def update_weight(self, name, dtype, shape, empty_cache=False):
+        """Broadcast weight to all vllm workers from source rank 0 (actor model)"""
+        if torch.distributed.get_rank() == 0:
+            logger.info(f"update weight: {name}, dtype: {dtype}, shape: {shape}")
+
+        assert dtype == self.model_config.dtype, f"mismatch dtype: src {dtype}, dst {self.model_config.dtype}"
+        weight = torch.empty(shape, dtype=dtype, device="cuda")
+        if self._model_update_with_ray:
+            import ray.util.collective as collective
+
+            collective.broadcast(weight, 0, group_name=self._model_update_group)
+        else:
+            self._model_update_group.broadcast(weight, src=0, stream=torch.cuda.current_stream())
+
+        del weight

--- a/scripts/llama/llama_vllm.sh
+++ b/scripts/llama/llama_vllm.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 PKU-Alignment Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+ACTOR_MODEL_NAME_OR_PATH="meta-llama/Llama-3.1-8B-Instruct" # actor model path
+CRITIC_MODEL_NAME_OR_PATH="../outputs/llama_rm" # critic model path
+REWARD_MODEL_NAME_OR_PATH="../outputs/llama_rm" # reward model path
+
+TRAIN_DATASETS="PKU-Alignment/PKU-SafeRLHF-single-dimension" # dataset path
+TRAIN_TEMPLATE="PKUSafeRLHF" # rlhf dataset template
+TRAIN_SPLIT="train" # split the rlhf dataset
+
+PTX_DATASETS="tatsu-lab/alpaca" # sft dataset path
+PTX_TEMPLATE="Alpaca" # sft dataset template
+PTX_SPLIT="train" # split the sft dataset
+
+export VLLM_DEVICES="0"
+
+DEEPSPEED_DEVICES="localhost:1,2,3,4,5,6,7"
+
+OUTPUT_DIR="../output/llama_ppo_vllm" # output dir
+# For wandb online logging
+export WANDB_API_KEY=""
+
+# Source the setup script
+source ./setup.sh
+
+# Execute deepspeed command
+deepspeed \
+  --master_port ${MASTER_PORT} \
+  --module align_anything.trainers.text_to_text.ppo_vllm \
+  --actor_model_name_or_path ${ACTOR_MODEL_NAME_OR_PATH} \
+  --reward_model_name_or_path ${REWARD_MODEL_NAME_OR_PATH} \
+  --reward_critic_model_name_or_path ${CRITIC_MODEL_NAME_OR_PATH} \
+  --train_datasets ${TRAIN_DATASETS} \
+  --train_split ${TRAIN_SPLIT} \
+  --train_template ${TRAIN_TEMPLATE} \
+  --ptx_split ${PTX_SPLIT} \
+  --ptx_datasets ${PTX_DATASETS} \
+  --ptx_template ${PTX_TEMPLATE} \
+  --output_dir ${OUTPUT_DIR}


### PR DESCRIPTION
# Description

This pull request supports wrapping the `actor` model with [vLLM engine](https://github.com/vllm-project/vllm) for sequence generation in `text-to-text ppo` training. It will greatly accelerate the ppo training process. Our results show that with vLLM engine, it only takes 22 minutes to finish ppo, while the baseline case needs ~150 minutes. 

> This experiment is done on 8*H800, LLaMA-3.1-8B-Instruct, 500 prompts on PKU-SafeRLHF

<img width="759" alt="image" src="https://github.com/user-attachments/assets/813c2f93-f069-4414-927c-fb6898b75c87" />

## Test

Please test your changes by running the following command:

```bash
cd scripts
bash test/test_text_to_text.sh ./opt PATH_TO_OUTPUT_ROOT_DIR
```

Here, `./opt` is the directory containing the test scripts for the `opt` model, and `PATH_TO_OUTPUT_ROOT_DIR` is the path to the output root directory. The test scripts will save ~1GB data to the output root directory and delete it after the test. Please ensure you have enough space on your disk.

## Lint

Please run the following command in the root directory to check your code style:

```bash
pip install pre-commit
pre-commit run --all-files
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/align-anything/blob/HEAD/.github/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
