### PR TITLE
Fix broken link of Evaluation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 [📘Documentation](https://align-anything.readthedocs.io/) |
 [🛠️Quick Start](#quick-start) |
 [🚀Algorithms](#algorithms) |
-[👀Evaluation](#evaluation) |
+[👀Evaluation](https://github.com/PKU-Alignment/eval-anything) |
 [🤔Reporting Issues](#report-issues)
 
 </div>


### PR DESCRIPTION
# Description

Broken link in README.md on line 30:

> [👀Evaluation](#evaluation) |

As mentioned in README.md, the evaluation component is now separated from align-anything and established as [eval-anything](https://github.com/PKU-Alignment/eval-anything), a dedicated repository for large-scale evaluation of any-to-any models.

## Motivation and Context

- [ ] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/align-anything/issues) for new features and bug fixes)

## Test

Docs fix, tests are not needed.

## Lint

Docs fix, lints are not needed.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/align-anything/blob/HEAD/.github/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
